### PR TITLE
PHP8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: php
 php:
-  - 5.3
-  - 5.4
+  - 8.0

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         }
     },
     "minimum-stability": "dev",
-    "keywords": ["configuration"]
+    "keywords": ["configuration"],
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    }
 }

--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -146,9 +146,9 @@ class IniParser {
             foreach ($sects as $s) {
                 if ($s === '^') {
                     $arr = array_merge($globals, $arr);
-                } elseif (array_key_exists($s, $output_sections)) {
+                } elseif (isset($output_sections[$s])) {
                     $arr = array_merge($output_sections[$s], $arr);
-                } elseif (array_key_exists($s, $sections)) {
+                } elseif (isset($sections[$s])) {
                     $arr = array_merge($sections[$s], $arr);
                 } else {
                     throw new UnexpectedValueException("IniParser: In file '{$this->file}', section '{$root}': Cannot inherit from unknown section '{$s}'");
@@ -194,7 +194,7 @@ class IniParser {
                         $current = array($current);
                     }
 
-                    if (!array_key_exists($current_key, $current)) {
+                    if (!isset($current[$current_key])) {
                         if (!empty($path)) {
                             $current[$current_key] = $this->getArrayValue();
                         } else {

--- a/tests/Test/IniParserTest.php
+++ b/tests/Test/IniParserTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Till Klampaeckel <till@php.net>
  */
-class IniParserTest extends PHPUnit_Framework_TestCase
+class IniParserTest extends TestCase
 {
     /**
      * This is a test-case I wrote because I think there are small bugs
@@ -23,10 +25,10 @@ class IniParserTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
      */
     public function testConfigNotFound()
     {
+        $this->expectException(InvalidArgumentException::class);
         new IniParser('/this/should/never/exist.ini');
     }
 
@@ -112,10 +114,10 @@ class IniParserTest extends PHPUnit_Framework_TestCase
     {
         $configObj = $this->getConfig('fixture04.ini');
 
-        $this->assertInternalType('array', $configObj['array1']);
+        $this->assertIsArray($configObj['array1']);
         $this->assertEquals(array('a','b','c'), $configObj['array1']);
 
-        $this->assertInternalType('array', $configObj['sect1']['array2']);
+        $this->assertIsArray($configObj['sect1']['array2']);
         $this->assertEquals(array('d','e','f'), $configObj['sect1']['array2']);
     }
 
@@ -132,11 +134,10 @@ class IniParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test that inheriting from an undefined section gives a nice error
-     *
-     * @expectedException UnexpectedValueException
      */
     public function testInvalidSectionReference()
     {
+        $this->expectException(UnexpectedValueException::class);
         $configObj = $this->getConfig('fixture06.ini');
     }
 
@@ -259,7 +260,7 @@ class IniParserTest extends PHPUnit_Framework_TestCase
         $parser->use_array_object = FALSE;
         $configArr = $parser->parse();
 
-        $this->assertInternalType('array', $configArr);
+        $this->assertIsArray($configArr);
     }
 
     /**


### PR DESCRIPTION
- Update tests to use recent **PHPUnit** version (**9.5**)
- PHP8: Fix `array_key_exists()` calls on objects …
Error: `array_key_exists(): Argument #2 ($array) must be of type array, ArrayObject given`
- PHP8: Update Travis CI build config